### PR TITLE
fix(security): restrict WuzAPI monitoring endpoints to admin-only

### DIFF
--- a/backend-hormonia/app/api/v2/monitoring/wuzapi.py
+++ b/backend-hormonia/app/api/v2/monitoring/wuzapi.py
@@ -3,15 +3,16 @@
 import logging
 from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from app.config import settings
+from app.dependencies.auth_dependencies import get_admin_user
 from app.integrations.wuzapi import get_wuzapi_client
 from app.utils.timezone import now_sao_paulo
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(get_admin_user)])
 
 
 @router.get("/session/status")

--- a/backend-hormonia/tests/integrations/wuzapi/test_wuzapi_session.py
+++ b/backend-hormonia/tests/integrations/wuzapi/test_wuzapi_session.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi import FastAPI
 
 from app.api.v2.monitoring.wuzapi import router
+from app.dependencies.auth_dependencies import get_admin_user
 from app.integrations.wuzapi.mock import MockWuzAPIClient
 
 
@@ -18,6 +19,11 @@ def mock_client():
 @pytest.fixture
 def app():
     app = FastAPI()
+
+    async def _admin_override():
+        return {"role": "admin"}
+
+    app.dependency_overrides[get_admin_user] = _admin_override
     app.include_router(router, prefix="/monitoring/wuzapi")
     return app
 


### PR DESCRIPTION
### Motivation
- The WuzAPI monitoring router exposed `/session/status` and `/session/qr` without authentication, returning the server-side WuzAPI token-backed session status and the base64 QR used for WhatsApp pairing, enabling remote takeover of the clinic WhatsApp integration.

### Description
- Added an admin dependency to the WuzAPI monitoring router by using `APIRouter(dependencies=[Depends(get_admin_user)])` in `backend-hormonia/app/api/v2/monitoring/wuzapi.py` so all endpoints under the router require an admin user.
- Updated the integration test fixture in `backend-hormonia/tests/integrations/wuzapi/test_wuzapi_session.py` to override `get_admin_user` in the test `FastAPI` app so existing endpoint behavior can be exercised under authorized access.

### Testing
- Ran `pytest -q backend-hormonia/tests/integrations/wuzapi/test_wuzapi_session.py`, which could not complete because test environment setup failed with `ModuleNotFoundError: No module named 'dotenv'` from `backend-hormonia/tests/conftest.py` and prevented executing the tests.
- The change is minimal and preserves original endpoint logic while adding the admin guard; tests were adapted to provide the required admin dependency override but could not be executed in this environment due to the missing test dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69af02f6cf7c832d8c72837d36ad2690)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Monitoring API endpoints now enforce admin authentication across all endpoints.

* **Tests**
  * Updated integration tests to properly handle authentication requirements during endpoint testing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/axisvitor/clinica-oncologica-v02/pull/115)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->